### PR TITLE
Fix katex.css export

### DIFF
--- a/.changeset/clean-llamas-count.md
+++ b/.changeset/clean-llamas-count.md
@@ -1,0 +1,5 @@
+---
+'@samplekit/preprocess-katex': patch
+---
+
+fix: katex.css export location

--- a/packages/preprocess-katex/package.json
+++ b/packages/preprocess-katex/package.json
@@ -13,13 +13,13 @@
 		"check": "tsc --noEmit",
 		"validate": "pnpm install --frozen-lockfile && pnpm format && pnpm lint && pnpm check",
 		"clean": "rm -rf dist",
-		"build": "pnpm clean && tsc",
+		"build": "pnpm clean && tsc && cp src/katex.css dist && cp -r node_modules/katex/dist/fonts dist",
 		"prepublishOnly": "pnpm build"
 	},
 	"exports": {
 		".": "./dist/index.js",
 		"./client": "./dist/client.js",
-		"./katex.css": "./node_modules/katex/dist/katex.css",
+		"./katex.css": "./dist/katex.css",
 		"./katex.js": "./dist/katex.js",
 		"./package.json": "./package.json"
 	},

--- a/packages/preprocess-katex/src/katex.css
+++ b/packages/preprocess-katex/src/katex.css
@@ -1,0 +1,1 @@
+@import 'katex/dist/katex.css';

--- a/sites/preprocessor-docs/src/app.css
+++ b/sites/preprocessor-docs/src/app.css
@@ -1,3 +1,4 @@
+@import '@samplekit/preprocess-katex/katex.css';
 @import './lib/styles/css/tokens.css';
 @import './lib/styles/css/themes.css';
 @import './lib/styles/css/code.css';

--- a/sites/preprocessor-docs/src/routes/+layout.svelte
+++ b/sites/preprocessor-docs/src/routes/+layout.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import '@samplekit/preprocess-katex/katex.css';
 	import '../app.css';
 	import { tick } from 'svelte';
 	import { browser } from '$app/environment';

--- a/sites/preprocessor-docs/src/routes/docs/math/+page.svelte
+++ b/sites/preprocessor-docs/src/routes/docs/math/+page.svelte
@@ -105,7 +105,7 @@ shiki-end -->
 		<span class="step-content">
 			<span class="lg:text-lg">
 				<!-- shiki-start
-d"diff-add" l"1" l"5-6" l"11-14"
+d"diff-add" l"1" l"5-6" l"11-16"
 ```ts
 import { processKatex, createKatexLogger } from '@samplekit/preprocess-katex';
 import adapter from '@sveltejs/adapter-auto';
@@ -120,6 +120,8 @@ const config = {
 		processKatex({
 			include: (filename) => filename.startsWith(preprocessorRoot),
 			logger: createKatexLogger(formatFilename),
+			// optionally use your own katex installation
+			// renderToString: katex.renderToString
 		}),
 		vitePreprocess(),
 	],
@@ -141,6 +143,22 @@ shiki-end -->
 			<a data-external href="https://marketplace.visualstudio.com/items?itemName=samplekit.svelte-pp-katex">
 				samplekit.svelte-pp-katex
 			</a>
+		</span>
+	</li>
+
+	<li class="step">
+		<span class="step-title">Import <code>katex.css</code> into your <code>app.css</code></span>
+		<span class="step-content">
+			<span class="lg:text-lg">
+				<!-- shiki-start
+p c"no-lines"
+```css
+@import '@samplekit/preprocess-katex/katex.css';
+/* optionally use your own katex installation */
+/* @import 'katex/dist/katex.css'; */
+```
+shiki-end -->
+			</span>
 		</span>
 	</li>
 </ol>

--- a/sites/samplekit.dev/src/app.css
+++ b/sites/samplekit.dev/src/app.css
@@ -1,3 +1,4 @@
+@import '@samplekit/preprocess-katex/katex.css';
 @import './lib/styles/css/tokens.css';
 @import './lib/styles/css/themes.css';
 @import './lib/styles/css/code.css';

--- a/sites/samplekit.dev/src/routes/+layout.svelte
+++ b/sites/samplekit.dev/src/routes/+layout.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import '@samplekit/preprocess-katex/katex.css';
 	import '../app.css';
 	import { tick } from 'svelte';
 	import { browser } from '$app/environment';


### PR DESCRIPTION
## What problem does this PR solve?

The `preprocess-katex` build script did not properly copy over `katex.css` to `dist`, so importing it through the reexport broke unless the package was independently installed.

## PR Checklist:

- [x] The PR body illustrates what problems are being solved.

- [x] `pnpm validate` has been run inside the changed workspace project(s).
      (You will need to run `pnpm build:dependencies && pnpm sync` first for sites.)

- [x] No NPM packages / VS Code extensions have changed, or if they have, a changeset has been created.
      (Create changesets by running `pnpm changeset` and following the instructions. If unsure, please make a note in the PR description.)

- [x] 'Allow edits from maintainers.' is checked or the PR branch is not a fork.
