### PR TITLE
loosen renderToString type

### DIFF
--- a/.changeset/stale-snakes-sneeze.md
+++ b/.changeset/stale-snakes-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@samplekit/preprocess-katex': patch
+---
+
+loosen renderToString type

--- a/packages/preprocess-katex/src/preprocess-katex.ts
+++ b/packages/preprocess-katex/src/preprocess-katex.ts
@@ -78,6 +78,15 @@ function restoreSvelte(mathString: string, extractedSvelteContent: string[]): st
 	});
 }
 
+type RenderToString = (
+	tex: string,
+	options: {
+		displayMode?: boolean | undefined;
+		throwOnError: true;
+		strict: (errorCode: string, errorMsg: string) => 'ignore' | undefined;
+	},
+) => string;
+
 export function processKatex({
 	include,
 	logger,
@@ -85,7 +94,7 @@ export function processKatex({
 }: {
 	include?: (filename: string) => boolean;
 	logger?: Logger;
-	renderToString?: (tex: string, options?: katex.KatexOptions) => string;
+	renderToString?: RenderToString;
 } = {}) {
 	return {
 		name: 'katex',

--- a/sites/samplekit.dev/src/routes/articles/preprocessors/+page.svelte
+++ b/sites/samplekit.dev/src/routes/articles/preprocessors/+page.svelte
@@ -468,6 +468,15 @@ const display = { start: String.raw`\[`, end: String.raw`\]` };
 const inline = { start: String.raw`\(`, end: String.raw`\)` };
 const delimLoc = { start: 3, end: -3 };
 
+type RenderToString = (
+	tex: string,
+	options: {
+		displayMode?: boolean | undefined;
+		throwOnError: true;
+		strict: (errorCode: string, errorMsg: string) => 'ignore' | undefined;
+	},
+) => string;
+
 export function processKatex({
 	include,
 	logger,
@@ -475,7 +484,7 @@ export function processKatex({
 }: {
 	include?: (filename: string) => boolean;
 	logger?: Logger;
-	renderToString?: (tex: string, options?: katex.KatexOptions) => string;
+	renderToString?: RenderToString;
 } = {}) {
 	return {
 		name: 'katex',
@@ -554,6 +563,15 @@ const catchStdErr = ({ tmpWrite, trappedFn }: { trappedFn: () => void; tmpWrite:
 	}//! d"diff-add"
 };//! d"diff-add"
 
+type RenderToString = (
+	tex: string,
+	options: {
+		displayMode?: boolean | undefined;
+		throwOnError: true;
+		strict: (errorCode: string, errorMsg: string) => 'ignore' | undefined;
+	},
+) => string;
+
 export function processKatex({
 	include,
 	logger,
@@ -561,7 +579,7 @@ export function processKatex({
 }: {
 	include?: (filename: string) => boolean;
 	logger?: Logger;
-	renderToString?: (tex: string, options?: katex.KatexOptions) => string;
+	renderToString?: RenderToString;
 } = {}) {
 	return {
 		name: 'katex',
@@ -649,7 +667,7 @@ shiki-end -->
 
 <CodeTopper title="preprocess-katex">
 	<!-- shiki-start
-d"diff-add" l"21-79" l"114" l"118" l"121-124" l"126"
+d"diff-add" l"21-79"
 ```ts
 import { walk } from 'estree-walker';
 import katex from 'katex';
@@ -731,6 +749,15 @@ function restoreSvelte(mathString: string, extractedSvelteContent: string[]): st
 	});
 }
 
+type RenderToString = (
+	tex: string,
+	options: {
+		displayMode?: boolean | undefined;
+		throwOnError: true;
+		strict: (errorCode: string, errorMsg: string) => 'ignore' | undefined;
+	},
+) => string;
+
 export function processKatex({
 	include,
 	logger,
@@ -738,7 +765,7 @@ export function processKatex({
 }: {
 	include?: (filename: string) => boolean;
 	logger?: Logger;
-	renderToString?: (tex: string, options?: katex.KatexOptions) => string;
+	renderToString?: RenderToString;
 } = {}) {
 	return {
 		name: 'katex',
@@ -764,19 +791,19 @@ export function processKatex({
 					let parsed;
 					try {
 						const rawInput = String.raw`${trimmed.slice(delimLoc.start, delimLoc.end)}`;
-						const { svelteFreeString, extractedSvelteContent } = replaceSvelteAndStore(rawInput);
+						const { svelteFreeString, extractedSvelteContent } = replaceSvelteAndStore(rawInput);//! d"diff-add"
 						const warns: Error[] = [];
 						catchStdErr({
 							trappedFn: () => {
-								const mathString = renderToString(svelteFreeString, {
+								const mathString = renderToString(svelteFreeString, {//! d"diff-add"
 									displayMode,
 									throwOnError: true,
-									strict: (errorCode: string, errorMsg: string) => {
-										if (errorCode === 'unknownSymbol' && errorMsg.startsWith('Unrecognized Unicode character'))
-											return 'ignore';
-									},
+									strict: (errorCode: string, errorMsg: string) => {//! d"diff-add"
+										if (errorCode === 'unknownSymbol' && errorMsg.startsWith('Unrecognized Unicode character'))//! d"diff-add"
+											return 'ignore';//! d"diff-add"
+									},//! d"diff-add"
 								});
-								parsed = restoreSvelte(mathString, extractedSvelteContent);
+								parsed = restoreSvelte(mathString, extractedSvelteContent);//! d"diff-add"
 							},
 							tmpWrite: (str) => {
 								if (!str.startsWith('No character metrics for ')) warns.push(Error(str));

--- a/sites/samplekit.dev/src/routes/articles/preprocessors/generated/metadata.ts
+++ b/sites/samplekit.dev/src/routes/articles/preprocessors/generated/metadata.ts
@@ -20,7 +20,7 @@ export default {
 		{ at: new Date('2024-03-20T20:11:27.000Z'), descriptions: ['Expand processor syntax beyond highlighting.'] },
 	],
 	articlePath: '/articles/preprocessors',
-	wordCount: 3891,
+	wordCount: 3957,
 	readingTime: 18,
 	toc: [
 		{


### PR DESCRIPTION
## What problem does this PR solve?

The type of the `renderToString` function was bound to `@types/katex`. This could cause users injecting future katex versions to experience type errors even if the desired interface is satisfied.

## PR Checklist:

- [x] The PR body illustrates what problems are being solved.

- [x] `pnpm validate` has been run inside the changed workspace project(s).
      (You will need to run `pnpm build:dependencies && pnpm sync` first for sites.)

- [x] No NPM packages / VS Code extensions have changed, or if they have, a changeset has been created.
      (Create changesets by running `pnpm changeset` and following the instructions. If unsure, please make a note in the PR description.)

- [x] 'Allow edits from maintainers.' is checked or the PR branch is not a fork.
