### PR TITLE
Fail fast on unsupported bundled Shiki lang/theme

### DIFF
--- a/.changeset/gorgeous-guests-fly.md
+++ b/.changeset/gorgeous-guests-fly.md
@@ -1,0 +1,5 @@
+---
+'@samplekit/preprocess-shiki': major
+---
+
+breaking: throw if passing an unsupported bundled lang/theme

--- a/packages/preprocess-shiki/src/defaultOpts.ts
+++ b/packages/preprocess-shiki/src/defaultOpts.ts
@@ -1,6 +1,7 @@
 import { createHighlighterCore } from '@shikijs/core';
+import { bundledLanguages } from 'shiki/langs';
+import { bundledThemes } from 'shiki/themes';
 import type { BundledLanguage, CreateHighlighterArgs, CreateOptsArgs, PreprocessOpts } from './types.js';
-// 'shiki' langs and themes are dynamically imported
 
 export const defaultBundledLangNames = [
 	'svelte',
@@ -64,14 +65,20 @@ export const defaultEscapeSvelte = (({ highlightedHtml }) =>
 const createDefaultHighlighter = async (a?: CreateHighlighterArgs) => {
 	const langs = [
 		...(a?.lang?.custom ?? []),
-		...(a?.lang?.bundled ?? defaultBundledLangNames).map((l) => import(/* @vite-ignore */ `shiki/langs/${l}.mjs`)),
+		...(a?.lang?.bundled ?? defaultBundledLangNames).map((l) => {
+			const lang = bundledLanguages[l];
+			if (!lang) throw new Error(`Language '${l}' is not a bundled Shiki language.`);
+			return lang;
+		}),
 	];
 
 	const themes = [
 		...(a?.theme?.custom ?? [import('./themes/darker.js')]),
-		...(a?.theme?.bundled?.map((t) => import(/* @vite-ignore */ `shiki/themes/${t}.mjs`)) ?? [
-			import('shiki/themes/rose-pine-dawn.mjs'),
-		]),
+		...(a?.theme?.bundled?.map((t) => {
+			const theme = bundledThemes[t];
+			if (!theme) throw new Error(`Theme '${t}' is not a bundled Shiki theme.`);
+			return theme;
+		}) ?? [import('shiki/themes/rose-pine-dawn.mjs')]),
 	];
 
 	return await createHighlighterCore({ themes, langs, loadWasm: import('shiki/wasm') });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,9 +384,6 @@ importers:
       postcss-js:
         specifier: ^4.0.1
         version: 4.0.1(postcss@8.4.47)
-      shiki:
-        specifier: ^1.22.0
-        version: 1.22.0
       svelte:
         specifier: ^5.0.2
         version: 5.0.2

--- a/sites/samplekit.dev/package.json
+++ b/sites/samplekit.dev/package.json
@@ -81,7 +81,6 @@
 		"magic-string": "^0.30.12",
 		"postcss": "^8.4.47",
 		"postcss-js": "^4.0.1",
-		"shiki": "^1.22.0",
 		"svelte": "^5.0.2",
 		"svelte-check": "^4.0.5",
 		"sveltekit-superforms": "^2.20.0",


### PR DESCRIPTION
## What problem does this PR solve?

Passing an unsupported bundled shiki theme/language id was silently ignored. Now it throws immediately on server start.

This change removes the dynamic imports, which don't help on the server anyway and required the sites in the pnpm workspace to install shiki separately.

## PR Checklist:

- [x] The PR body illustrates what problems are being solved.

- [x] `pnpm validate` has been run inside the changed workspace project(s).
      (You will need to run `pnpm build:dependencies && pnpm sync` first for sites.)

- [x] No NPM packages / VS Code extensions have changed, or if they have, a changeset has been created.
      (Create changesets by running `pnpm changeset` and following the instructions. If unsure, please make a note in the PR description.)

- [x] 'Allow edits from maintainers.' is checked or the PR branch is not a fork.
